### PR TITLE
Bugfix for update process.

### DIFF
--- a/Lib/swap.js
+++ b/Lib/swap.js
@@ -2,7 +2,8 @@ const { join, dirname } = require( "path" ),
       fs = require( "fs-extra" ),
       os = require( "os" ),
       { spawn } = require( "child_process" ),
-      LOG_PATH = join( nw.App.dataPath, "swap.log" );
+      LOG_PATH = join( nw.App.dataPath, "swap.log" ),
+      IS_OSX = /^darwin/.test( process.platform );
 
 
 /**
@@ -29,9 +30,14 @@ async function copy( from, to ){
  * @param {string} backupPath
  * @returns {Promise}
  */
-async function swap( origHomeDir, selfDir, backupPath ){
-  await copy( origHomeDir, backupPath );
-  await copy( selfDir, origHomeDir );
+async function swap( origHomeDir, selfDir, runner ){
+    if (IS_OSX) {
+        await copy( join( origHomeDir, runner ), join( origHomeDir, runner + ".bak" ) );
+        await copy( selfDir, origHomeDir );
+    } else {
+        await copy( origHomeDir, origHomeDir + ".bak" );
+        await copy( selfDir, origHomeDir );
+    }
 }
 /**
  * Launch detached process

--- a/example/server/README.md
+++ b/example/server/README.md
@@ -2,8 +2,8 @@
 
 It's a static server that keeps manifest and last app releases. 
 Releases of nwjs app are built with 'nw-builder' (as example), the structure of builds is next:
-macos - %APPNAME%.app (compressed *.app file for release);
-win/linux - %FOLDER_NAME% with binary and other necessary files inside (compressed all files inside this folder for release);
+* macos - %APPNAME%.app (compressed *.app file for release);
+* win/linux - %FOLDER_NAME% with binary and other necessary files inside (compressed all files inside this folder for release);
 
 ## package.json
 ```

--- a/example/server/README.md
+++ b/example/server/README.md
@@ -5,6 +5,8 @@ Releases of nwjs app are built with 'nw-builder' (as example), the structure of 
 * macos - %APPNAME%.app (compressed *.app file for release);
 * win/linux - %FOLDER_NAME% with binary and other necessary files inside (compressed all files inside this folder for release);
 
+Updater during update process will create backup of your current application, for macos in the same folder %APPNAME%.app.bak will be created, on win/linux it will create %FOLDER_NAME%.bak in the folder with application folder %FOLDER_NAME%.
+
 ## package.json
 ```
 {

--- a/example/server/README.md
+++ b/example/server/README.md
@@ -1,6 +1,9 @@
 # Release Server Example
 
-It's a static server that keeps manifest and last app releases
+It's a static server that keeps manifest and last app releases. 
+Releases of nwjs app are built with 'nw-builder' (as example), the structure of builds is next:
+macos - %APPNAME%.app (compressed *.app file for release);
+win/linux - %FOLDER_NAME% with binary and other necessary files inside (compressed all files inside this folder for release);
 
 ## package.json
 ```
@@ -10,7 +13,15 @@ It's a static server that keeps manifest and last app releases
     "linux64": {
       "url": "http://localhost:8080/releases/nw-autoupdater-demo-linux-x64.zip",
       "size": 102680557
-    }
+    },
+    "win64": {
+      "url": "http://localhost:8080/releases/nw-autoupdater-demo-win-x64.zip",
+      "size": 102680557
+    },
+    "mac64": {
+      "url": "http://localhost:8080/releases/nw-autoupdater-demo-mac-x64.tar.gz",
+      "size": 102680557
+    }    
   }
 }
 ```


### PR DESCRIPTION
Hi, will you join my pull request, if yes - I need to prepare it, also we need to update README to make it more descriptive about initial data, I found some bugs:

My nwjs app builds with 'nw-builder':
macos - %APPNAME%.app (compressed *.app file for release);
win/linux - %FOLDER_NAME% with binary and other necessary files inside (compressed all files inside this folder for release);

* macos - excessive path spaces quoting with "\ " in args/argv.
* unhandled paths for MacOS %APPNAME%.app when nwjs binary is inside package.
* differences between backup creation on mac/win_linux, we need create %APPNAME%.app.bak for macos, and %FOLDER_NAME%.bak for win/linux.
* fix for MacOS Sierra, did you notice new app is starting in sanbox Apple called AppTranslocation?

I tested on macos sierra / win10 / ubuntu 12 - works fine with my changes.