### PR TITLE
Bugfix for Mac OS + new feature.

### DIFF
--- a/Lib/Swap/Abstract.js
+++ b/Lib/Swap/Abstract.js
@@ -39,11 +39,11 @@ case $i in
 esac
 done
 ` + ( swapScript ||
-`echo "rsync -a\${VERBOSE} --delete \${APP_PATH}/. \${BAK_PATH}/"
-rsync -a\${VERBOSE} --delete "\${APP_PATH}/." "\${BAK_PATH}/"
+`echo "rsync -al\${VERBOSE} --delete \${APP_PATH}/. \${BAK_PATH}/"
+rsync -al\${VERBOSE} --delete "\${APP_PATH}/." "\${BAK_PATH}/"
 echo " "
-echo "rsync -a\${VERBOSE} --delete \${UPDATE_PATH}/. \${APP_PATH}/"
-rsync -a\${VERBOSE} --delete "\${UPDATE_PATH}/." "\${APP_PATH}/"
+echo "rsync -al\${VERBOSE} --delete \${UPDATE_PATH}/. \${APP_PATH}/"
+rsync -al\${VERBOSE} --delete "\${UPDATE_PATH}/." "\${APP_PATH}/"
 ` );
   }
 

--- a/Lib/env.js
+++ b/Lib/env.js
@@ -24,7 +24,7 @@ const EXEC_DIR = IS_OSX ?
 const PKG_NAME = "nw-autoupdater";
 const LOG_FILE = `${PKG_NAME}.log`;
 const UPDATE_DIR = join( os.tmpdir(), PKG_NAME );
-const BACKUP_DIR = `${EXEC_DIR}.bak`;
+const BACKUP_DIR = `${EXEC_DIR}.bak_` + Math.floor(Date.now() / 1000);
 const LOG_PATH = join( nw.App.dataPath, LOG_FILE );
 
 function getExecutable( name )

--- a/Lib/env.js
+++ b/Lib/env.js
@@ -24,7 +24,7 @@ const EXEC_DIR = IS_OSX ?
 const PKG_NAME = "nw-autoupdater";
 const LOG_FILE = `${PKG_NAME}.log`;
 const UPDATE_DIR = join( os.tmpdir(), PKG_NAME );
-const BACKUP_DIR = `${EXEC_DIR}.bak_` + Math.floor(Date.now() / 1000);
+const BACKUP_DIR = `${EXEC_DIR}.bak_${Math.floor(Date.now() / 1000)}`;
 const LOG_PATH = join( nw.App.dataPath, LOG_FILE );
 
 function getExecutable( name )

--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ const updateFile = await updater.download( rManifest, { debounceTime: 100 });
 **Returns**: `Promise<filepath: string>`
 
 
+### cleanUp
+Clean temp directory nw-autoupdater
+```
+await updater.cleanUp(rManifest);
+```
+**Params**
+- `rManifest` - manifest of the release server
+
+**Returns**: `Promise`
+
+
 ### unpack
 Unpack downloaded update
 ```

--- a/example/client-strategy-script/index.html
+++ b/example/client-strategy-script/index.html
@@ -37,7 +37,8 @@
             output.innerHTML = `Installing...\n`;
             console.log( "install progress", Math.floor( installFiles / totalFiles * 100 ), "%" );
           });
-
+         
+          await updater.cleanUp(rManifest);
           const updateFile = await updater.download( rManifest );
           await updater.unpack( updateFile );
           alert( `The application will automatically restart to finish installing the update` );

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const EventEmitter = require( "events" ),
       unpackTarGz = require( "./Lib/unpackTarGz" ),
       unpackZip = require( "./Lib/unpackZip" ),
       debounce = require( "debounce" ),
+      fs = require( "fs-extra" ),
 
       { readJson, download }  = require( "./Lib/request" ),
       { launch, rtrim } = require( "./Lib/utils" ),
@@ -54,7 +55,17 @@ class AutoUpdater extends EventEmitter {
     Object.assign( this, this.options.strategy === "ScriptSwap" ? ScriptSwapStrategy : AppSwapStrategy );
 
   }
-
+  /**
+   * Cleanup temp folder updateDir
+   * @returns {Promise}
+   */
+  async cleanUp( remoteManifest ){
+    const release = remoteManifest.packages[ PLATFORM_FULL ];
+    if ( !release ) {
+        throw new Error( `No release matches the platfrom ${PLATFORM_FULL}` );
+    }
+    return await fs.removeSync(this.options.updateDir);
+  }
   /**
    * Read package.json from the release server
    * @returns {Promise<JSON>}


### PR DESCRIPTION
Hi Dmitry,

I prepared new PR.

1. Added key `-l` to rsync SwapScript strategy, why? As you know nwjs starting from 0.22.0 uses relative symlinks inside package. So we need copy them (if applicable) properly:
```
$ man rsync
-l, --links                 copy symlinks as symlinks
```
2. Better to create different backups for every update to distinguish them. 
3. Added `cleanUp()` method to solve Mac OS bug, which hangs forever as `installing...`.

Now update process works like a charm on Mac OS. 
I see another float bug w/ Mac OS, but not critical, it is regarding consequent two updates, which prevents run for final build, though you can do it manually without any issues or any backup build as well (symlinks are correct).