### PR TITLE
Reject with launch error

### DIFF
--- a/Lib/utils.js
+++ b/Lib/utils.js
@@ -65,7 +65,7 @@ async function launch( runnerPath, argv, cwd, logPath ){
 
       child.on( "error", ( e ) => {
         fs.writeSync( log, [ "ERROR:", e, "\r\n" ].join( " " ), "utf-8" );
-        reject( log );
+        reject( e );
       });
 
        child.unref();


### PR DESCRIPTION
Reject with launch error.

Instead of rejecting with what logs as `3`, get the actual error produced.