### PR TITLE
Show actual unpack zip error

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ class AutoUpdater extends EventEmitter {
          try {
           await unpackZip( updateFile, updateDir, debounce( onProgress, debounceTime ) );
          } catch ( e ) {
-            throw new Error( `Cannot unpack .zip package ${updateFile}` );
+            throw new Error( `Cannot unpack .zip package ${updateFile}: ${e.message}` );
          }
          break;
       default:


### PR DESCRIPTION
Show actual unpack zip error otherwise it is hard to figure out what is going wrong.

ex.

> Cannot unpack .zip package C:\Users\xxx\AppData\Local\Temp\win32.zip: EBUSY: resource busy or locked, open 'C:\Users\xxx\AppData\Local\Temp\nw-autoupdater\d3dcompiler_47.dll'
