### PR TITLE
Add extraArgs param when restarting apps

### DIFF
--- a/Lib/Strategy/AppSwap.js
+++ b/Lib/Strategy/AppSwap.js
@@ -8,12 +8,12 @@ const { join  } = require( "path" ),
    * Restart and launch detached swap
    * @returns {Promise}
    */
-  async function restartToSwap(){
+  async function restartToSwap(extraArgs = []){
     const { execDir, executable, updateDir, backupDir, logPath } = this.options,
           tpmUserData = join( nw.App.dataPath, "swap" ),
           app = join( updateDir, executable ),
           args = [ `--user-data-dir=${tpmUserData}`,
-            `--swap=${execDir}`, `--bak-dir=${backupDir}` ];
+            `--swap=${execDir}`, `--bak-dir=${backupDir}` ].concat( extraArgs );
 
     if ( IS_OSX ) {
       await launch( "open", [ "-a", app, "--args", ...args ], updateDir, logPath );
@@ -63,12 +63,12 @@ const { join  } = require( "path" ),
    * REstart after swap
    * @returns {Promise}
    */
-  async function restart(){
+  async function restart(extraArgs = []){
     const { execDir, executable, updateDir, logPath } = this.options,
           app = join( execDir, executable );
 
      if ( IS_OSX ) {
-      await launch( "open", [ "-a", app, "--args" ], execDir, logPath );
+      await launch( "open", [ "-a", app, "--args" ].concat( extraArgs ), execDir, logPath );
     } else {
       await launch( app, [], execDir, logPath );
     }

--- a/Lib/Strategy/ScriptSwap.js
+++ b/Lib/Strategy/ScriptSwap.js
@@ -6,10 +6,10 @@ const { join  } = require( "path" ),
    * Restart and launch detached swap
    * @returns {Promise}
    */
-  async function restartToSwap(){
+  async function restartToSwap(extraArgs = []){
     const { updateDir, logPath } = this.options,
           swap = swapFactory( this.options ),
-          args = swap.getArgs();
+          args = swap.getArgs().concat( extraArgs );
 
     swap.extractScript( updateDir );
     await launch( swap.getRunner(), args, updateDir, logPath );

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Library provides low-level API to control NW.js app auto-updates. This project c
 - `download( rManifest )` downloads the latest available release matching the host platform (according to the `packages` map of the remote manifest)
 - `unpack( updateFile )` unpacks the release archive (`zip` or `tar.gz`) in a temporary directory
 - Strategy AppSwap
-  - `restartToSwap()` closes the app and launches the downloaded release
+  - `restartToSwap( extraArgs )` closes the app and launches the downloaded release
   - `isSwapRequest()` - checks if we need to go the swap flow (while running in tmp and therefore having the initial app directory unlocked for writing)
   - `swap()` - backs up actual version and replaces it with the new one
-  - `restart()` - restarts the updated app from its original location
+  - `restart( extraArgs )` - restarts the updated app from its original location
 - Strategy ScriptSwap
   - `restartToSwap()` closes the app and launches the swap script, which launches the application when it's done
 
@@ -146,6 +146,9 @@ Close this version of app and start the downloaded one with --swap param
 await updater.restartToSwap();
 ```
 
+**Params**
+- `extraArgs` - (OPTIONAL) Extra arguments to be passed to the newly started app
+
 **Returns**: `Promise`
 
 
@@ -190,6 +193,9 @@ Restarts the updated app
 ```
 await updater.restart();
 ```
+
+**Params**
+- `extraArgs` - (OPTIONAL) Extra arguments to be passed to the newly started app
 
 **Returns**: `Promise`
 


### PR DESCRIPTION
Add `extraArgs` param when restarting apps.

 - `AppSwap.restartToSwap`
 - `AppSwap.restart`

---

We use this in the Gitter desktop app for passing along `--passthrough-remote-debugging-port` so we can access the devtools and debug throughout the autoupdate process, see https://gitlab.com/gitlab-org/gitter/desktop/#cli-parameters