### PR TITLE
fix: delete extraneous files from destination directory on Windows

### DIFF
--- a/Lib/Swap/Win.js
+++ b/Lib/Swap/Win.js
@@ -15,13 +15,13 @@ SET updateDir=%~2
 SET backupDir=%~3
 SET runner=%~4
 SET verbose=%~5
-
-rmdir "%backupDir%" /s /q
-xcopy "%execDir%" "%backupDir%" /e /i /h /c /y
-xcopy "%updateDir%" "%execDir%" /e /i /h /c /y
+` + (this.options.swapScript ||
+`rmdir "%backupDir%" /s /q
+robocopy "%execDir%" "%backupDir%" /mir
+robocopy "%updateDir%" "%execDir%" /mir
 
 "%execDir%\\%runner%"
-`;
+`);
   }
 
   extractScript( homeDir )


### PR DESCRIPTION
Support custom swapScript. Delete extraneous files from dest dirs.

Unlike linux swap script, windows script doesn't delete files which were deleted from the target. It may cause problems. For example,

Old version:
_./server.js_

New version:
_~~./server.js~~_
_./server/index.js_

After autoupdate in Windows:
_./server.js_
_./server/index.js_

In this scenario `require('./server')` will use server.js file from the older version.

Using `robocopy /mir` instead of `xcopy` will resolve this problem.