### PR TITLE
Bug fix - Passing args in AppSwap restart function

### DIFF
--- a/Lib/Strategy/AppSwap.js
+++ b/Lib/Strategy/AppSwap.js
@@ -70,7 +70,7 @@ const { join  } = require( "path" ),
      if ( IS_OSX ) {
       await launch( "open", [ "-a", app, "--args" ].concat( extraArgs ), execDir, logPath );
     } else {
-      await launch( app, [], execDir, logPath );
+      await launch(app, [].concat(extraArgs), execDir, logPath);
     }
     nw.App.quit();
   }


### PR DESCRIPTION
- On the AppSwap strategy, we're able to pass args on OSX apps, but not others.